### PR TITLE
Implement basic auth handlers

### DIFF
--- a/src/db/entity/mod.rs
+++ b/src/db/entity/mod.rs
@@ -1,1 +1,1 @@
-// SeaORM entities will be defined here
+pub mod users;

--- a/src/db/entity/users.rs
+++ b/src/db/entity/users.rs
@@ -1,0 +1,22 @@
+use sea_orm::entity::prelude::*;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub username: String,
+    pub password_hash: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        panic!("no relations")
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/handlers/auth_handler.rs
+++ b/src/handlers/auth_handler.rs
@@ -1,10 +1,57 @@
 // Authentication related handlers
 
-use axum::{response::IntoResponse, Json};
+use axum::{response::IntoResponse, Extension, Json};
+use bcrypt::{hash, verify};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
 use serde_json::json;
+use uuid::Uuid;
 
-pub async fn login() -> impl IntoResponse {
-    Json(json!({ "message": "login" }))
+use crate::{
+    db::entity::users,
+    types::auth_types::{AuthResponse, LoginRequest, RegisterRequest},
+    utils::jwt,
+};
+
+pub async fn user_register(
+    Extension(db): Extension<DatabaseConnection>,
+    Json(payload): Json<RegisterRequest>,
+) -> impl IntoResponse {
+    let hashed = match hash(payload.password, 4) {
+        Ok(h) => h,
+        Err(_) => return Json(json!({ "error": "hash" })),
+    };
+
+    let user = users::ActiveModel {
+        id: Set(Uuid::new_v4()),
+        username: Set(payload.username),
+        password_hash: Set(hashed),
+    };
+
+    match users::Entity::insert(user).exec(&db).await {
+        Ok(_) => Json(json!({ "status": "ok" })),
+        Err(_) => Json(json!({ "error": "insert" })),
+    }
+}
+
+pub async fn user_login(
+    Extension(db): Extension<DatabaseConnection>,
+    Json(payload): Json<LoginRequest>,
+) -> impl IntoResponse {
+    let user = users::Entity::find()
+        .filter(users::Column::Username.eq(payload.username))
+        .one(&db)
+        .await
+        .unwrap();
+
+    if let Some(u) = user {
+        if verify(payload.password, &u.password_hash).unwrap_or(false) {
+            if let Ok(token) = jwt::encode_jwt(u.id) {
+                return Json(json!(AuthResponse { token }));
+            }
+        }
+    }
+
+    Json(json!({ "error": "invalid credentials" }))
 }
 
 pub async fn protected() -> impl IntoResponse {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,7 +13,8 @@ pub fn guarded_routes() -> Router {
 pub fn unguarded_routes() -> Router {
     Router::new()
         .route("/health", get(handlers::health_handler::health))
-        .route("/login", post(handlers::auth_handler::login))
+        .route("/login", post(handlers::auth_handler::user_login))
+        .route("/register", post(handlers::auth_handler::user_register))
 }
 
 pub fn create_routes(db: DatabaseConnection) -> Router {

--- a/src/types/auth_types.rs
+++ b/src/types/auth_types.rs
@@ -1,7 +1,20 @@
 // Authentication related types
 
-#[derive(Debug, serde::Deserialize)]
-pub struct LoginPayload {
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
     pub username: String,
     pub password: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthResponse {
+    pub token: String,
 }

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,5 +1,19 @@
-// JSON Web Token utilities placeholder
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-pub fn create_token() {
-    // TODO: implement token creation
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+}
+
+pub fn encode_jwt(user_id: Uuid) -> jsonwebtoken::errors::Result<String> {
+    let claims = Claims {
+        sub: user_id.to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(b"secret"),
+    )
 }


### PR DESCRIPTION
## Summary
- model `users` table for SeaORM
- add JWT encoding utility
- define auth request/response structs
- implement `user_register` and `user_login` handlers
- expose login/register routes

## Testing
- `cargo check -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_6864c5b67c50832d983efb86d97f8f5a