### PR TITLE
Implement JWT authentication guard

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,4 +1,8 @@
-use axum::{middleware::from_fn, routing::{get, post}, Extension, Router};
+use axum::{
+    Extension, Router,
+    middleware::from_fn,
+    routing::{get, post},
+};
 use sea_orm::DatabaseConnection;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
@@ -7,7 +11,7 @@ use crate::{handlers, utils};
 pub fn guarded_routes() -> Router {
     Router::new()
         .route("/protected", get(handlers::auth_handler::protected))
-        .layer(from_fn(utils::guards::auth_guard))
+        .layer(from_fn(utils::guards::jwt_guard))
 }
 
 pub fn unguarded_routes() -> Router {

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,4 +1,5 @@
-use jsonwebtoken::{encode, EncodingKey, Header};
+use crate::types::error_types::AppError;
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -16,4 +17,14 @@ pub fn encode_jwt(user_id: Uuid) -> jsonwebtoken::errors::Result<String> {
         &claims,
         &EncodingKey::from_secret(b"secret"),
     )
+}
+
+pub fn decode_jwt(token: &str) -> Result<Uuid, AppError> {
+    let data = decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(b"secret"),
+        &Validation::new(Algorithm::HS256),
+    )
+    .map_err(|_| AppError::Unauthorized)?;
+    Uuid::parse_str(&data.claims.sub).map_err(|_| AppError::Unauthorized)
 }


### PR DESCRIPTION
## Summary
- implement token decoding in `utils::jwt` with `decode_jwt`
- add `jwt_guard` middleware that reads an Authorization bearer token
- apply guard to protected routes

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6864c795828c832d9805cb1f0e35e3c1