### PR TITLE
Adjust router API paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ async fn main() {
         .await
         .expect("Failed to connect to database");
 
-    let app: Router = routes::create_routes(db.clone());
+    let app: Router = routes::create_router(db.clone());
 
     let addr = "0.0.0.0:5000";
     println!("Server running on {addr}");

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -10,18 +10,18 @@ use crate::{handlers, utils};
 
 pub fn guarded_routes() -> Router {
     Router::new()
-        .route("/protected", get(handlers::auth_handler::protected))
+        .route("/api/protected", get(handlers::auth_handler::protected))
         .layer(from_fn(utils::guards::jwt_guard))
 }
 
 pub fn unguarded_routes() -> Router {
     Router::new()
-        .route("/health", get(handlers::health_handler::health))
-        .route("/login", post(handlers::auth_handler::user_login))
-        .route("/register", post(handlers::auth_handler::user_register))
+        .route("/api/health", get(handlers::health_handler::health))
+        .route("/api/auth/login", post(handlers::auth_handler::user_login))
+        .route("/api/auth/register", post(handlers::auth_handler::user_register))
 }
 
-pub fn create_routes(db: DatabaseConnection) -> Router {
+pub fn create_router(db: DatabaseConnection) -> Router {
     Router::new()
         .merge(unguarded_routes())
         .merge(guarded_routes())


### PR DESCRIPTION
## Summary
- add `/api` prefix to routes
- rename `create_routes` -> `create_router`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6864ca4f8f88832d9a3febdfd08004d8