### PR TITLE
Expose env settings via constants

### DIFF
--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -1,12 +1,10 @@
-use dotenv::dotenv;
 use rust_axum_boilerplate::db::migration::Migrator;
 use sea_orm_migration::prelude::*;
+use rust_axum_boilerplate::utils::DATABASE_URL;
 
 #[tokio::main]
 async fn main() {
-    dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL not set");
-    let db = sea_orm::Database::connect(&database_url)
+    let db = sea_orm::Database::connect(DATABASE_URL.as_str())
         .await
         .expect("Failed to connect to database");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,12 @@ mod types;
 mod db;
 
 use axum::Router;
-use dotenv::dotenv;
 use sea_orm::{Database, DatabaseConnection};
+use utils::DATABASE_URL;
 
 #[tokio::main]
 async fn main() {
-    dotenv().ok();
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL not set");
-    let db: DatabaseConnection = Database::connect(&database_url)
+    let db: DatabaseConnection = Database::connect(DATABASE_URL.as_str())
         .await
         .expect("Failed to connect to database");
 

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -1,3 +1,21 @@
 // Constants used across the project
 
+use dotenv::dotenv;
+use lazy_static::lazy_static;
+use std::env;
+
 pub const TOKEN_PREFIX: &str = "Bearer";
+
+lazy_static! {
+    /// Database connection string loaded from the environment
+    pub static ref DATABASE_URL: String = {
+        dotenv().ok();
+        env::var("DATABASE_URL").expect("DATABASE_URL must be set")
+    };
+
+    /// Secret used to sign and verify access tokens
+    pub static ref ACCESS_TOKEN: String = {
+        dotenv().ok();
+        env::var("ACCESS_TOKEN").expect("ACCESS_TOKEN must be set")
+    };
+}

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,4 +1,5 @@
 use crate::types::error_types::AppError;
+use crate::utils::ACCESS_TOKEN;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -15,14 +16,14 @@ pub fn encode_jwt(user_id: Uuid) -> jsonwebtoken::errors::Result<String> {
     encode(
         &Header::default(),
         &claims,
-        &EncodingKey::from_secret(b"secret"),
+        &EncodingKey::from_secret(ACCESS_TOKEN.as_bytes()),
     )
 }
 
 pub fn decode_jwt(token: &str) -> Result<Uuid, AppError> {
     let data = decode::<Claims>(
         token,
-        &DecodingKey::from_secret(b"secret"),
+        &DecodingKey::from_secret(ACCESS_TOKEN.as_bytes()),
         &Validation::new(Algorithm::HS256),
     )
     .map_err(|_| AppError::Unauthorized)?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,5 @@
 pub mod constants;
+
+pub use constants::{ACCESS_TOKEN, DATABASE_URL};
 pub mod jwt;
 pub mod guards;


### PR DESCRIPTION
## Summary
- expose `DATABASE_URL` and `ACCESS_TOKEN` constants via `lazy_static`
- re-export constants in `utils`
- use new constants in main binary, migration tool and JWT utilities

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6864cb765048832dbeaddc4fdad1c25d