### PR TITLE
Add detailed request/response logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1047,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1975,7 +1995,9 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "bcrypt",
+ "bytes",
  "dotenv",
+ "hyper",
  "jsonwebtoken",
  "lazy_static",
  "sea-orm",
@@ -2875,6 +2897,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ bcrypt = "0.15"
 uuid = { version = "1", features = ["v4"] }
 lazy_static = "1"
 thiserror = "1"
+bytes = "1"
+hyper = { version = "0.14", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod routes;
 mod types;
 mod utils;
 
+use axum::middleware::from_fn;
 use axum::{Extension, extract::DefaultBodyLimit, http::HeaderName, response::IntoResponse};
 use sea_orm::{Database, DatabaseConnection};
 use tower_http::{
@@ -12,7 +13,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use utils::DATABASE_URL;
+use utils::{DATABASE_URL, logging};
 
 async fn not_found() -> impl IntoResponse {
     types::error_types::AppError::NotFound
@@ -47,7 +48,8 @@ async fn main() {
         ))
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive());
+        .layer(CorsLayer::permissive())
+        .layer(from_fn(logging::logger));
 
     let addr = "0.0.0.0:5000";
     tracing::info!("Server running on {addr}");

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,0 +1,76 @@
+use axum::{
+    body::{Body, Bytes, boxed},
+    http::Request,
+    middleware::Next,
+    response::Response,
+};
+use hyper::body::to_bytes;
+use tracing::info;
+
+/// Routes where request and response bodies should not be logged
+pub const BODY_BLACKLIST: &[&str] = &["/api/auth/register", "/api/auth/login"];
+
+/// Middleware that logs requests and responses using `tracing`.
+///
+/// It logs headers and `x-request-id` for all requests. For routes not in
+/// `BODY_BLACKLIST` it also logs the request and response bodies.
+pub async fn logger(mut req: Request<Body>, next: Next<Body>) -> Response {
+    let path = req.uri().path().to_owned();
+    let method = req.method().to_string();
+    let request_id = req
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    let headers = format!("{:?}", req.headers());
+
+    let log_body = !BODY_BLACKLIST.iter().any(|p| p == &path);
+
+    let req_body_string;
+    if log_body {
+        let bytes = to_bytes(req.body_mut())
+            .await
+            .unwrap_or_else(|_| Bytes::new());
+        req_body_string = String::from_utf8_lossy(&bytes).to_string();
+        *req.body_mut() = Body::from(bytes);
+    } else {
+        req_body_string = String::new();
+    }
+
+    let mut res = next.run(req).await;
+    let status = res.status();
+
+    let res_body_string;
+    if log_body {
+        let bytes = to_bytes(res.body_mut())
+            .await
+            .unwrap_or_else(|_| Bytes::new());
+        res_body_string = String::from_utf8_lossy(&bytes).to_string();
+        *res.body_mut() = boxed(Body::from(bytes));
+    } else {
+        res_body_string = String::new();
+    }
+
+    if log_body {
+        info!(
+            request_id,
+            method = %method,
+            path = %path,
+            status = %status,
+            headers = %headers,
+            req_body = %req_body_string,
+            res_body = %res_body_string,
+        );
+    } else {
+        info!(
+            request_id,
+            method = %method,
+            path = %path,
+            status = %status,
+            headers = %headers,
+        );
+    }
+
+    res
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod constants;
 
 pub use constants::{ACCESS_TOKEN, DATABASE_URL};
-pub mod jwt;
 pub mod guards;
+pub mod jwt;
+pub mod logging;


### PR DESCRIPTION
## Summary
- add logging middleware to capture request/response bodies
- export logging module
- wire middleware into main router
- include hyper/bytes dependencies for middleware

## Testing
- `cargo check`
- `cargo check --all-targets`
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6864eb6e4e08832d99fb44567fe18628