### PR TITLE
Implement logout endpoint

### DIFF
--- a/src/handlers/auth_handler.rs
+++ b/src/handlers/auth_handler.rs
@@ -69,6 +69,16 @@ pub async fn user_login(
     Err(AppError::Unauthorized)
 }
 
+pub async fn user_logout() -> impl IntoResponse {
+    let body = Json(json!({ "status": "ok" }));
+    let mut response = body.into_response();
+    let cookie_value = "auth_token=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0".to_string();
+    response
+        .headers_mut()
+        .insert(header::SET_COOKIE, cookie_value.parse().unwrap());
+    response
+}
+
 pub async fn protected() -> impl IntoResponse {
     Json(json!({ "message": "protected" }))
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -17,6 +17,10 @@ pub fn unguarded_routes() -> Router {
         .route("/api/health", get(handlers::health_handler::health))
         .route("/api/auth/login", post(handlers::auth_handler::user_login))
         .route(
+            "/api/auth/logout",
+            post(handlers::auth_handler::user_logout),
+        )
+        .route(
             "/api/auth/register",
             post(handlers::auth_handler::user_register),
         )


### PR DESCRIPTION
## Summary
- add `user_logout` handler that clears auth cookie
- route `/api/auth/logout` to the new handler

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6865665fb714832d98d1f04ad84454a9