### PR TITLE
Add configurable bcrypt cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The application reads configuration from environment variables using `dotenv`. T
 
 - `DATABASE_URL` &ndash; connection string for the database. Example: `postgres://user:password@localhost:5432/app`.
 - `ACCESS_TOKEN` &ndash; secret used to sign and verify JWT access tokens.
+- `BCRYPT_COST` &ndash; cost factor for password hashing. Defaults to `12` if not set.
 
 These variables can be placed in a `.env` file at the project root or exported in your shell.
 

--- a/src/handlers/auth_handler.rs
+++ b/src/handlers/auth_handler.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use axum::{Extension, Json, http::header, response::IntoResponse};
 use bcrypt::{hash, verify};
+use crate::utils::BCRYPT_COST;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
 use serde_json::json;
 use uuid::Uuid;
@@ -20,8 +21,8 @@ pub async fn user_register(
     Extension(db): Extension<DatabaseConnection>,
     CustomJson(payload): CustomJson<RegisterReq>,
 ) -> Result<GenericJsonRes, AppError> {
-    let hashed =
-        hash(payload.password, 4).map_err(|e| AppError::InternalServerError(e.to_string()))?;
+    let hashed = hash(payload.password, *BCRYPT_COST)
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
 
     let user = users::ActiveModel {
         id: Set(Uuid::new_v4()),

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -18,4 +18,13 @@ lazy_static! {
         dotenv().ok();
         env::var("ACCESS_TOKEN").expect("ACCESS_TOKEN must be set")
     };
+
+    /// Cost factor used by bcrypt when hashing passwords
+    pub static ref BCRYPT_COST: u32 = {
+        dotenv().ok();
+        env::var("BCRYPT_COST")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(12)
+    };
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
 pub mod constants;
 
-pub use constants::{ACCESS_TOKEN, DATABASE_URL};
+pub use constants::{ACCESS_TOKEN, DATABASE_URL, BCRYPT_COST};
 pub mod guards;
 pub mod jwt;
 pub mod logging;


### PR DESCRIPTION
## Summary
- load `BCRYPT_COST` from environment in constants
- export `BCRYPT_COST`
- use `BCRYPT_COST` for user registration password hashing
- document the new variable in README

## Testing
- `cargo check`
- `cargo test` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68656b2bb564832d9d3da5aee41738a9