### PR TITLE
Add token expiration handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,8 +426,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2066,6 +2068,7 @@ dependencies = [
  "axum",
  "bcrypt",
  "bytes",
+ "chrono",
  "dotenv",
  "hyper 0.14.32",
  "jsonwebtoken",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ lazy_static = "1"
 thiserror = "1"
 bytes = "1"
 hyper = { version = "0.14", features = ["full"] }
+chrono = { version = "0.4", features = ["clock", "serde"] }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The application reads configuration from environment variables using `dotenv`. T
 - `DATABASE_URL` &ndash; connection string for the database. Example: `postgres://user:password@localhost:5432/app`.
 - `ACCESS_TOKEN` &ndash; secret used to sign and verify JWT access tokens.
 - `BCRYPT_COST` &ndash; cost factor for password hashing. Defaults to `12` if not set.
+- `TOKEN_EXPIRATION_SECS` &ndash; lifetime of issued JWT tokens in seconds. Defaults to `3600`.
 
 These variables can be placed in a `.env` file at the project root or exported in your shell.
 

--- a/src/handlers/auth_handler.rs
+++ b/src/handlers/auth_handler.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     utils::jwt,
 };
+use crate::utils::TOKEN_EXPIRATION_SECS;
 use axum::{Extension, Json, http::header, response::IntoResponse};
 use bcrypt::{hash, verify};
 use crate::utils::BCRYPT_COST;
@@ -56,8 +57,9 @@ pub async fn user_login(
                 }));
                 let mut response = body.into_response();
                 let cookie_value = format!(
-                    "auth_token={}; HttpOnly; Secure; SameSite=Lax; Path=/",
-                    token
+                    "auth_token={}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age={}",
+                    token,
+                    *TOKEN_EXPIRATION_SECS
                 );
                 response.headers_mut().insert(
                     header::SET_COOKIE,

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -27,4 +27,13 @@ lazy_static! {
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(12)
     };
+
+    /// Lifetime in seconds for issued JWT tokens
+    pub static ref TOKEN_EXPIRATION_SECS: usize = {
+        dotenv().ok();
+        env::var("TOKEN_EXPIRATION_SECS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(3600)
+    };
 }

--- a/src/utils/jwt.rs
+++ b/src/utils/jwt.rs
@@ -1,17 +1,20 @@
 use crate::types::error_types::AppError;
-use crate::utils::ACCESS_TOKEN;
+use crate::utils::{ACCESS_TOKEN, TOKEN_EXPIRATION_SECS};
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use chrono::Utc;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     sub: String,
+    exp: usize,
 }
 
 pub fn encode_jwt(user_id: Uuid) -> jsonwebtoken::errors::Result<String> {
     let claims = Claims {
         sub: user_id.to_string(),
+        exp: (Utc::now().timestamp() as usize) + *TOKEN_EXPIRATION_SECS,
     };
     encode(
         &Header::default(),
@@ -27,5 +30,8 @@ pub fn decode_jwt(token: &str) -> Result<Uuid, AppError> {
         &Validation::new(Algorithm::HS256),
     )
     .map_err(|_| AppError::Unauthorized)?;
+    if data.claims.exp < Utc::now().timestamp() as usize {
+        return Err(AppError::Unauthorized);
+    }
     Uuid::parse_str(&data.claims.sub).map_err(|_| AppError::Unauthorized)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
 pub mod constants;
 
-pub use constants::{ACCESS_TOKEN, DATABASE_URL, BCRYPT_COST};
+pub use constants::{ACCESS_TOKEN, DATABASE_URL, BCRYPT_COST, TOKEN_EXPIRATION_SECS};
 pub mod guards;
 pub mod jwt;
 pub mod logging;


### PR DESCRIPTION
## Summary
- add token lifetime constant and export it
- include `exp` claim in JWTs and check during decoding
- set cookie Max-Age on login
- document `TOKEN_EXPIRATION_SECS` variable

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68656c85ec40832daa50610ed4eb01fb