### PR TITLE
Add configurable log folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The application reads configuration from environment variables using `dotenv`. T
 - `ACCESS_TOKEN` &ndash; secret used to sign and verify JWT access tokens.
 - `BCRYPT_COST` &ndash; cost factor for password hashing. Defaults to `12` if not set.
 - `TOKEN_EXPIRATION_SECS` &ndash; lifetime of issued JWT tokens in seconds. Defaults to `3600`.
+- `LOG_DIR` &ndash; directory where log files are written. Defaults to `logs`.
 
 These variables can be placed in a `.env` file at the project root or exported in your shell.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use utils::{DATABASE_URL, logging};
+use utils::{DATABASE_URL, LOG_DIR, logging};
 
 async fn not_found() -> impl IntoResponse {
     types::error_types::AppError::NotFound
@@ -21,7 +21,7 @@ async fn not_found() -> impl IntoResponse {
 
 #[tokio::main]
 async fn main() {
-    let file_appender = tracing_appender::rolling::daily("logs", "app.log");
+    let file_appender = tracing_appender::rolling::daily(LOG_DIR.as_str(), "app.log");
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);
 
     tracing_subscriber::registry()
@@ -53,10 +53,6 @@ async fn main() {
 
     let addr = "0.0.0.0:5000";
     tracing::info!("Server running on {addr}");
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .unwrap();
-    axum::serve(listener, app)
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -36,4 +36,10 @@ lazy_static! {
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(3600)
     };
+
+    /// Directory where log files will be written
+    pub static ref LOG_DIR: String = {
+        dotenv().ok();
+        env::var("LOG_DIR").unwrap_or_else(|_| "logs".into())
+    };
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
 pub mod constants;
 
-pub use constants::{ACCESS_TOKEN, DATABASE_URL, BCRYPT_COST, TOKEN_EXPIRATION_SECS};
+pub use constants::{ACCESS_TOKEN, BCRYPT_COST, DATABASE_URL, LOG_DIR, TOKEN_EXPIRATION_SECS};
 pub mod guards;
 pub mod jwt;
 pub mod logging;


### PR DESCRIPTION
## Summary
- add `LOG_DIR` constant and export it
- use `LOG_DIR` in `main.rs`
- document `LOG_DIR` in README

## Testing
- `cargo fmt -- --check`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68656e838b58832dacfedd9e7cb15d05